### PR TITLE
fix: address all compiler warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.3.1]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `Regexp::execute_with_remainder` is deprecated as the semantic is confusing.
   Use `Regexp::execute` together with `MatchResult::before` and
   `MatchResult::after` instead.
+- Updated syntax to v0.6.24+012953835 (#30)
 
 ## [0.3.0]
 

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "moonbitlang/regexp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "readme": "README.md",
   "repository": "https://github.com/moonbitlang/regexp.mbt",
   "license": "Apache-2.0",

--- a/prebuild/src/stub.mbt
+++ b/prebuild/src/stub.mbt
@@ -15,7 +15,7 @@
 ///| Run the program.
 pub fn run() -> Result[Unit, Unit] {
   let mut result = Ok(())
-  @promise.spawn(async fn(_defer) {
+  @promise.spawn(async fn(_defer) raise {
     top() catch {
       error => {
         result = Err(())

--- a/src/chars.mbt
+++ b/src/chars.mbt
@@ -88,7 +88,7 @@ fn is_word_char_at(input : @string.View, sp : Int) -> Bool {
   if sp == -1 || sp == input.length() {
     return false
   }
-  let c = input.char_at(sp)
+  let c = input.get_char(sp).unwrap()
   is_word_char(c)
 }
 

--- a/src/impl.mbt
+++ b/src/impl.mbt
@@ -22,7 +22,7 @@ priv enum Instruction {
   /// Zero-width assertions
   Assertion(Predicate)
   Backreference(Int)
-} derive(Show)
+}
 
 ///|
 priv enum Predicate {
@@ -32,7 +32,7 @@ priv enum Predicate {
   EndLine
   WordBoundary
   NoWordBoundary
-} derive(Show, ToJson)
+} derive(Show, ToJson(style="flat"))
 
 ///|
 /// A thread represents a point in the execution of the VM.
@@ -106,9 +106,8 @@ fn add_thread(
       let assertion = match pred {
         BeginText => sp == 0
         EndText => sp == content.length()
-        BeginLine => sp == 0 || content.charcode_at(sp - 1) == '\n'.to_int()
-        EndLine =>
-          sp == content.length() || content.charcode_at(sp) == '\n'.to_int()
+        BeginLine => sp == 0 || content[sp - 1] == '\n'
+        EndLine => sp == content.length() || content[sp] == '\n'
         WordBoundary =>
           is_word_char_at(content, sp - 1) != is_word_char_at(content, sp)
         NoWordBoundary =>
@@ -171,7 +170,7 @@ fn vm(
     let actual_char = if sp == input.length() {
       (-1).unsafe_to_char()
     } else {
-      input.char_at(sp)
+      input.get_char(sp).unwrap()
     }
     let next_sp = if actual_char.to_int() > 0xFFFF { sp + 2 } else { sp + 1 }
     for thread in clist {
@@ -210,8 +209,8 @@ fn vm(
           guard len != 0
           let next_sp = sp + len
           if next_sp <= input.length() &&
-            input.charcodes(start~, end~) ==
-            input.charcodes(start=sp, end=next_sp) {
+            input.view(start_offset=start, end_offset=end) ==
+            input.view(start_offset=sp, end_offset=next_sp) {
             add_thread(
               input,
               instructions,

--- a/src/impl.mbt
+++ b/src/impl.mbt
@@ -59,7 +59,7 @@ fn add_thread(
   instructions : Array[Instruction],
   inst_gen : Array[Int],
   thread : Thread,
-  clist : Array[Thread]
+  clist : Array[Thread],
 ) -> Unit {
   if inst_gen[thread.pc] == thread.sp {
     // already on the list
@@ -150,7 +150,7 @@ fn vm(
   instructions : Array[Instruction],
   input : @string.View,
   captures : Int,
-  allow_exponentiaion~ : Bool = false
+  allow_exponentiaion~ : Bool = false,
 ) -> Array[Int] {
   guard instructions is [.., Save(1), Matched]
   let inst_gen = Array::make(instructions.length(), -1)

--- a/src/impl_wbtest.mbt
+++ b/src/impl_wbtest.mbt
@@ -39,7 +39,7 @@ test {
   ]
   let captures = vm(instructions, "aab", 1)
   inspect(captures, content="[0, 3]")
-  inspect("aab".charcodes(start=0, end=3), content="aab")
+  inspect("aab".view(start_offset=0, end_offset=3), content="aab")
 }
 
 ///|
@@ -95,7 +95,9 @@ test "priority" (t : @test.T) {
   let captures = vm(instructions, "aabbcc", 4)
   inspect(captures, content="[0, 6, 0, 3, 3, 5, 5, 6]")
   for i = 0; i < captures.length(); i = i + 2 {
-    t.writeln("aabbcc".charcodes(start=captures[i], end=captures[i + 1]))
+    t.writeln(
+      "aabbcc".view(start_offset=captures[i], end_offset=captures[i + 1]),
+    )
   }
   t.snapshot(filename="priority.txt")
 }

--- a/src/internal/unicode/unicode.mbti
+++ b/src/internal/unicode/unicode.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/regexp/internal/unicode"
 
 // Values
@@ -10,6 +11,8 @@ let case_folding : Map[Char, Char]
 let general_category_property_value_alises : Map[String, String]
 
 let general_category_ranges : Map[String, Array[Char]]
+
+// Errors
 
 // Types and methods
 

--- a/src/parse.mbt
+++ b/src/parse.mbt
@@ -145,7 +145,7 @@ fn Parser::new(input : @string.View, flags : Flags) -> Parser {
 /// Throws: Error_ when parsing fails
 fn parse(
   regex : @string.View,
-  flags~ : Flags = Flags::default()
+  flags~ : Flags = Flags::default(),
 ) -> ParseResult raise RegexpError {
   let parser = Parser::new(regex, flags)
   let result = parser.parse_expression()
@@ -1004,7 +1004,7 @@ fn Parser::parse_unicode_property(self : Parser) -> String raise RegexpError {
 fn Parser::parse_general_category(
   self : Parser,
   property_name : String,
-  neg : Bool
+  neg : Bool,
 ) -> Ast raise RegexpError {
   // First, normalize the property name using aliases
   let normalized_name = match

--- a/src/regexp.mbti
+++ b/src/regexp.mbti
@@ -1,3 +1,4 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/regexp"
 
 import(
@@ -5,7 +6,13 @@ import(
 )
 
 // Values
-fn compile(@string.StringView, flags~ : @string.StringView = ..) -> Regexp raise RegexpError
+fn compile(@string.StringView, flags? : @string.StringView) -> Regexp raise RegexpError
+
+// Errors
+pub suberror RegexpError {
+  RegexpError(err~ : Err, source_fragment~ : @string.StringView)
+}
+impl Show for RegexpError
 
 // Types and methods
 pub enum Err {
@@ -39,11 +46,6 @@ fn Regexp::group_by_name(Self, String) -> Int?
 fn Regexp::group_count(Self) -> Int
 fn Regexp::group_names(Self) -> Array[String]
 fn Regexp::match_(Self, @string.StringView) -> MatchResult?
-
-pub suberror RegexpError {
-  RegexpError(err~ : Err, source_fragment~ : @string.StringView)
-}
-impl Show for RegexpError
 
 // Type aliases
 

--- a/src/top.mbt
+++ b/src/top.mbt
@@ -33,7 +33,7 @@
 /// ```
 pub fn compile(
   regexp : @string.View,
-  flags~ : @string.View = ""
+  flags~ : @string.View = "",
 ) -> Regexp raise RegexpError {
   regexp
   |> parse(flags={
@@ -170,7 +170,7 @@ pub fn Regexp::execute(self : Regexp, input : @string.View) -> MatchResult {
 #deprecated("Use `Regexp::execute` and `MatchResult::before`/`after` instead.")
 pub fn Regexp::execute_with_remainder(
   self : Regexp,
-  input : @string.View
+  input : @string.View,
 ) -> (MatchResult, @string.View) {
   let captures = vm(
     self.instructions,


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

- Replace deprecated string methods with modern equivalents
  - Use get_char().unwrap() instead of char_at()
  - Use direct indexing instead of charcode_at()
  - Use view() with proper parameters instead of charcodes()
- Add style="flat" to ToJson derives to address deprecation warnings
- Remove unused Show derive from Instruction enum

This commit resolves all actionable compiler warnings while maintaining 
backward compatibility and test functionality.