### PR TITLE
fix: char class

### DIFF
--- a/src/parse.mbt
+++ b/src/parse.mbt
@@ -592,6 +592,7 @@ fn Parser::parse_char_class(self : Parser) -> Ast raise RegexpError {
         }
         self.input = rest
         match ch {
+          // If they are themselves character classes, expand them
           'd' => {
             ranges_is_digit.each(chars.push(_)) // digit character class
             continue
@@ -616,38 +617,6 @@ fn Parser::parse_char_class(self : Parser) -> Ast raise RegexpError {
             ranges_is_not_white_space_or_line_terminator.each(chars.push(_)) // non-whitespace character class
             continue
           }
-          // ControlEscape
-          't' => {
-            ['\t', '\t'].each(chars.push(_))
-            continue
-          }
-          'n' => {
-            ['\n', '\n'].each(chars.push(_))
-            continue
-          }
-          'v' => {
-            ['\u{b}', '\u{b}'].each(chars.push(_))
-            continue
-          }
-          'f' => {
-            ['\u{c}', '\u{c}'].each(chars.push(_))
-            continue
-          }
-          'r' => {
-            ['\r', '\r'].each(chars.push(_))
-            continue
-          }
-          // backspace
-          'b' => {
-            ['\u{8}', '\u{8}'].each(chars.push(_))
-            continue
-          }
-          'u' => {
-            // Unicode escape \u{aaaa} or \uaaaa  
-            let unicode_char = self.parse_unicode_escape()
-            [unicode_char, unicode_char].each(chars.push(_))
-            continue
-          }
           'p' | 'P' as flag => {
             // Unicode property \p{property_name}
             let property_name = self.parse_unicode_property()
@@ -660,6 +629,18 @@ fn Parser::parse_char_class(self : Parser) -> Ast raise RegexpError {
             }
             continue
           }
+          // ControlEscape
+          't' => '\t'
+          'n' => '\n'
+          'v' => '\u{b}'
+          'f' => '\u{c}'
+          'r' => '\r'
+          // backspace
+          'b' => '\u{8}'
+          'u' =>
+            // Unicode escape \u{aaaa} or \uaaaa  
+            self.parse_unicode_escape()
+
           // reserve c and k
           'c' | 'k' =>
             raise RegexpError(err=InvalidEscape, source_fragment=escape)
@@ -673,7 +654,7 @@ fn Parser::parse_char_class(self : Parser) -> Ast raise RegexpError {
     }
 
     // Check for character range (e.g., a-z)
-    if self.input is ['-', .. rest] {
+    if self.input is (['-', .. rest] as range_rest) {
       // Look ahead after '-', ensure it's not ']' and there are more characters
       let input_copy = self.input
       self.input = rest // consume '-'
@@ -688,7 +669,29 @@ fn Parser::parse_char_class(self : Parser) -> Ast raise RegexpError {
               )
             }
             self.input = rest
-            ch
+            // Handle escaped characters properly - the same logic as in the main parsing
+            match ch {
+              // ControlEscape
+              't' => '\t'
+              'n' => '\n'
+              'v' => '\u{b}'
+              'f' => '\u{c}'
+              'r' => '\r'
+              'b' => '\u{8}' // backspace
+              'u' =>
+                // Unicode escape \u{aaaa} or \uaaaa
+                self.parse_unicode_escape()
+              // For character classes like \d, \w, \s - these cannot be used in ranges
+              'd' | 'D' | 'w' | 'W' | 's' | 'S' | 'p' | 'P' =>
+                raise RegexpError(
+                  err=InvalidCharClass,
+                  source_fragment=range_rest,
+                )
+              // reserve c and k
+              'c' | 'k' =>
+                raise RegexpError(err=InvalidEscape, source_fragment=self.input)
+              _ => ch
+            }
           }
           _ => {
             self.input = rest

--- a/src/parser_wbtest.mbt
+++ b/src/parser_wbtest.mbt
@@ -751,3 +751,51 @@ test "parse backreference" {
     ),
   )
 }
+
+///|
+test "parse character class range with escaped end character" {
+  // Test unicode escapes in ranges
+  let regex = parse("[a-\\u007A]").ast // Should parse as range from 'a' to 'z' (U+007A)
+  @json.inspect(regex, content=(["CharClass neg=false",["'a'","'u'","'0'","'0'","'0'","'0'","'7'","'7'","'A'","'A'"]]))
+  let regex = parse("[a-\\u{7A}]").ast // Should parse as range from 'a' to 'z' (U+007A)
+  @json.inspect(regex, content=(["CharClass neg=false",["'a'","'u'","'{'","'{'","'7'","'7'","'A'","'A'","'}'","'}'"]]))
+
+  // Test with literal backslash in range - backslash (0x5C) < 'z' (0x7A)
+  let regex = parse("[\\\\-z]").ast // Should parse as range from '\' to 'z'
+  @json.inspect(regex, content=["CharClass neg=false", ["'\\\\'", "'z'"]])
+
+  // Test invalid range (end char < start char) - tab comes before 'z', so this should error
+  let result = try? parse("[z-\\t]")
+  inspect(
+    result.map(ignore),
+    content="Err(RegexpError(err=InvalidCharClass, source_fragment=\"]\"))",
+  )
+
+  // Test invalid: character classes like \d cannot be used in ranges on right side
+  let result = try? parse("[a-\\d]")
+  inspect(
+    result.map(ignore),
+    content="Ok(())",
+  )
+
+  // Test escaped characters on both sides of range - newline (0x0A) to carriage return (0x0D)
+  let regex = parse("[\\n-\\r]").ast
+  @json.inspect(regex, content=[
+    "CharClass neg=false",
+    ["'\\n'", "'\\n'", "'-'", "'-'", "'\\r'", "'\\r'"],
+  ])
+
+  // Test range with special escape : \s-\s should be treated as literal characters '-'
+  let regex = parse("[\\s-\\s]").ast
+  @json.inspect(regex, content=[
+    "CharClass neg=false",
+    [
+      "'\\t'", "'\\r'", "' '", "' '", "' '", "' '", "' '", "' '", "' '",
+      "' '", "'\\u{2028}'", "'\\u{2029}'", "' '", "' '", "' '", "' '",
+      "'　'", "'　'", "'\\u{feff}'", "'\\u{feff}'", "'-'", "'-'", "'\\t'", "'\\r'",
+      "' '", "' '", "' '", "' '", "' '", "' '", "' '", "' '", "'\\u{2028}'",
+      "'\\u{2029}'", "' '", "' '", "' '", "' '", "'　'", "'　'", "'\\u{feff}'",
+      "'\\u{feff}'",
+    ],
+  ])
+}

--- a/src/parser_wbtest.mbt
+++ b/src/parser_wbtest.mbt
@@ -756,9 +756,9 @@ test "parse backreference" {
 test "parse character class range with escaped end character" {
   // Test unicode escapes in ranges
   let regex = parse("[a-\\u007A]").ast // Should parse as range from 'a' to 'z' (U+007A)
-  @json.inspect(regex, content=(["CharClass neg=false",["'a'","'u'","'0'","'0'","'0'","'0'","'7'","'7'","'A'","'A'"]]))
+  @json.inspect(regex, content=(["CharClass neg=false",["'a'","'z'"]]))
   let regex = parse("[a-\\u{7A}]").ast // Should parse as range from 'a' to 'z' (U+007A)
-  @json.inspect(regex, content=(["CharClass neg=false",["'a'","'u'","'{'","'{'","'7'","'7'","'A'","'A'","'}'","'}'"]]))
+  @json.inspect(regex, content=(["CharClass neg=false",["'a'","'z'"]]))
 
   // Test with literal backslash in range - backslash (0x5C) < 'z' (0x7A)
   let regex = parse("[\\\\-z]").ast // Should parse as range from '\' to 'z'
@@ -775,15 +775,14 @@ test "parse character class range with escaped end character" {
   let result = try? parse("[a-\\d]")
   inspect(
     result.map(ignore),
-    content="Ok(())",
+    content=(
+      #|Err(RegexpError(err=InvalidCharClass, source_fragment="-\\d]"))
+    ),
   )
 
   // Test escaped characters on both sides of range - newline (0x0A) to carriage return (0x0D)
   let regex = parse("[\\n-\\r]").ast
-  @json.inspect(regex, content=[
-    "CharClass neg=false",
-    ["'\\n'", "'\\n'", "'-'", "'-'", "'\\r'", "'\\r'"],
-  ])
+  @json.inspect(regex, content=(["CharClass neg=false",["'\\n'","'\\r'"]]))
 
   // Test range with special escape : \s-\s should be treated as literal characters '-'
   let regex = parse("[\\s-\\s]").ast

--- a/src/regex_test.mbt
+++ b/src/regex_test.mbt
@@ -78,7 +78,12 @@ test "unicode escape sequences" {
 
   // Test in character classes
   let regex = @regexp.compile("[\\u{41}-\\u{43}]")
-  inspect(regex.execute("B").results(), content="[]")
+  inspect(
+    regex.execute("B").results(),
+    content=(
+      #|[Some("B")]
+    ),
+  )
   inspect(regex.execute("D").matched(), content="false")
 
   // Test with \uaaaa format in character classes
@@ -1073,14 +1078,13 @@ test "unicode and international characters" {
 
   // Test unicode character classes
   let regex = @regexp.compile("[\\u4e00-\\u9fff]+")
-  if regex.execute("Hello 世界 World").matched() {
-    inspect(
-      regex.execute("Hello 世界 World").results(),
-      content=(
-        #|["世界"]
-      ),
-    )
-  }
+  assert_true(regex.execute("Hello 世界 World").matched())
+  inspect(
+    regex.execute("Hello 世界 World").results(),
+    content=(
+      #|[Some("世界")]
+    ),
+  )
 
   // Test emoji (if supported)
   let regex = @regexp.compile("😀")


### PR DESCRIPTION
Previously, any escape in the char class are treated as a single character, which was incorrect when having ranges. This PR fixes them.

cc @hackwaly 