### PR TITLE
Ignore MoonBit build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 _coverage
 _build/
 target
+_build


### PR DESCRIPTION
## Summary
- Add `target` and `_build` entries to `.gitignore`

## Rationale
- Prepare the repository for upcoming migration and reduce noise from generated build artifacts while addressing deprecation-related cleanup

## Implementation Details
- Updated ignore rules in `.gitignore` to cover common MoonBit build output directories
